### PR TITLE
perf: concat buffer()

### DIFF
--- a/src/cached_source.rs
+++ b/src/cached_source.rs
@@ -101,6 +101,10 @@ impl<T: Source + Hash + PartialEq + Eq + 'static> Source for CachedSource<T> {
   fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
     self.inner.to_writer(writer)
   }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    self.inner.flatten()
+  }
 }
 
 impl<T: Source + Hash + PartialEq + Eq + 'static> StreamChunks

--- a/src/concat_source.rs
+++ b/src/concat_source.rs
@@ -109,7 +109,11 @@ impl Source for ConcatSource {
   }
 
   fn flatten(&self) -> Vec<&dyn Source> {
-    self.children.iter().flat_map(|item| item.flatten()).collect()
+    self
+      .children
+      .iter()
+      .flat_map(|item| item.flatten())
+      .collect()
   }
 }
 

--- a/src/concat_source.rs
+++ b/src/concat_source.rs
@@ -107,6 +107,10 @@ impl Source for ConcatSource {
     }
     Ok(())
   }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    self.children.iter().flat_map(|item| item.flatten()).collect()
+  }
 }
 
 impl Hash for ConcatSource {

--- a/src/original_source.rs
+++ b/src/original_source.rs
@@ -70,6 +70,10 @@ impl Source for OriginalSource {
   fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
     writer.write_all(self.value.as_bytes())
   }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    vec![self]
+  }
 }
 
 impl Hash for OriginalSource {

--- a/src/raw_source.rs
+++ b/src/raw_source.rs
@@ -95,6 +95,10 @@ impl Source for RawSource {
       RawSource::Source(i) => i.as_bytes(),
     })
   }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    vec![self]
+  }
 }
 
 impl Hash for RawSource {

--- a/src/replace_source.rs
+++ b/src/replace_source.rs
@@ -146,6 +146,10 @@ impl<T: Source + Hash + PartialEq + Eq + 'static> Source for ReplaceSource<T> {
   fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
     writer.write_all(self.source().as_bytes())
   }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    self.inner.flatten()
+  }
 }
 
 impl<T: Source> StreamChunks for ReplaceSource<T> {

--- a/src/source.rs
+++ b/src/source.rs
@@ -39,6 +39,9 @@ pub trait Source:
     self.dyn_hash(state);
   }
 
+  /// flatten the source tree
+  fn flatten(&self) -> Vec<&dyn Source>;
+
   /// Writes the source into a writer, preferably a `std::io::BufWriter<std::io::Write>`.
   fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()>;
 }
@@ -62,6 +65,11 @@ impl Source for BoxSource {
 
   fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
     self.as_ref().to_writer(writer)
+  }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    // vec![self]
+    self.as_ref().flatten()
   }
 }
 

--- a/src/source_map_source.rs
+++ b/src/source_map_source.rs
@@ -110,6 +110,10 @@ impl Source for SourceMapSource {
   fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
     writer.write_all(self.value.as_bytes())
   }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    vec![self]
+  }
 }
 
 impl Hash for SourceMapSource {

--- a/tests/compat_source.rs
+++ b/tests/compat_source.rs
@@ -31,6 +31,10 @@ impl Source for CompatSource {
   fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
     writer.write_all(self.0.as_bytes())
   }
+
+  fn flatten(&self) -> Vec<&dyn Source> {
+    vec![self]
+  }
 }
 
 impl StreamChunks for CompatSource {


### PR DESCRIPTION
1. In the current implementation, when called `concatSource.buffer()`, the process will recursively call the child `buffer` and concat them together, assuming we have three level source each node of tree is `ConcatSource`  except the leaf node, each `rawSource` is one byte, the whole source file is 9 byte. Because each `buffer` call of `concatSource` will eagerly construct a new buffer, so in the worst case , i it will allocate `h * bytes of sourceFile` memory (`h` is the height of the source tree), in such scenario the function call allocate 27KB which is three times of  size of the sourceFile, if the height of the source tree is pretty big, then `buffer` call may become a performance bottleneck.  
2. Introduce `flatten` function , it flattens the sourceTree into a `Vec<&dyn Source>` which filter the `ConcatSource`, this could avoid duplicating allocation for same content.
![image](https://user-images.githubusercontent.com/17974631/221499262-5067dc60-5483-45b0-94c0-58b0ea2cb836.png)
