### PR TITLE
perf: reduce memory allocation while generating sourcemaps

### DIFF
--- a/src/cached_source.rs
+++ b/src/cached_source.rs
@@ -177,8 +177,8 @@ mod tests {
         source_map: SourceMap::new(
           None,
           ";AACA".to_string(),
-          vec!["index.js".to_string()],
-          vec!["// DELETE IT\nconsole.log(1)".to_string()],
+          vec!["index.js".into()],
+          vec!["// DELETE IT\nconsole.log(1)".into()],
           vec![],
         ),
       })

--- a/src/replace_source.rs
+++ b/src/replace_source.rs
@@ -189,6 +189,10 @@ impl<T: Source + Hash + PartialEq + Eq + 'static> Source for ReplaceSource<T> {
 }
 
 impl<T: Source> StreamChunks for ReplaceSource<T> {
+  fn mappings_size_hint(&self) -> usize {
+    self.replacements.lock().len() * 2
+  }
+
   fn stream_chunks(
     &self,
     options: &crate::MapOptions,

--- a/src/source_map_source.rs
+++ b/src/source_map_source.rs
@@ -260,15 +260,21 @@ mod tests {
       source_map: SourceMap::new(
         None,
         "AAAA".to_string(),
-        ["".to_string()],
-        ["".to_string()],
-        [],
+        vec!["".into()],
+        vec!["".into()],
+        vec![],
       ),
     });
     let b = SourceMapSource::new(WithoutOriginalOptions {
       value: "hello world\n",
       name: "hello.txt",
-      source_map: SourceMap::new(None, "AAAA".to_string(), [], [], []),
+      source_map: SourceMap::new(
+        None,
+        "AAAA".to_string(),
+        vec![],
+        vec![],
+        vec![],
+      ),
     });
     let c = SourceMapSource::new(WithoutOriginalOptions {
       value: "hello world\n",
@@ -276,9 +282,9 @@ mod tests {
       source_map: SourceMap::new(
         None,
         "AAAA".to_string(),
-        ["hello-source.txt".to_string()],
-        ["hello world\n".to_string()],
-        [],
+        vec!["hello-source.txt".into()],
+        vec!["hello world\n".into()],
+        vec![],
       ),
     });
     let sources = [a, b, c].into_iter().map(|s| {
@@ -344,9 +350,9 @@ mod tests {
       source_map: SourceMap::new(
         None,
         "AAAA;AACA".to_string(),
-        ["hello1".to_string()],
-        [],
-        [],
+        vec!["hello1".into()],
+        vec![],
+        vec![],
       ),
     });
     let b = SourceMapSource::new(WithoutOriginalOptions {
@@ -355,9 +361,9 @@ mod tests {
       source_map: SourceMap::new(
         None,
         "AAAA,EAAE".to_string(),
-        ["hello2".to_string()],
-        [],
-        [],
+        vec!["hello2".into()],
+        vec![],
+        vec![],
       ),
     });
     let b2 = SourceMapSource::new(WithoutOriginalOptions {
@@ -366,9 +372,9 @@ mod tests {
       source_map: SourceMap::new(
         None,
         "AAAA,EAAE".to_string(),
-        ["hello3".to_string()],
-        [],
-        [],
+        vec!["hello3".into()],
+        vec![],
+        vec![],
       ),
     });
     let c = SourceMapSource::new(WithoutOriginalOptions {
@@ -377,9 +383,9 @@ mod tests {
       source_map: SourceMap::new(
         None,
         "AAAA".to_string(),
-        ["hello4".to_string()],
-        [],
-        [],
+        vec!["hello4".into()],
+        vec![],
+        vec![],
       ),
     });
     let source = ConcatSource::new([

--- a/src/with_indices.rs
+++ b/src/with_indices.rs
@@ -34,10 +34,8 @@ impl<T: AsRef<str>> WithIndices<T> {
     });
 
     let str_len = self.line.as_ref().len() as u32;
-    let start =
-      indices_indexes.get(start_index).unwrap_or(&str_len).clone() as usize;
-    let end =
-      indices_indexes.get(end_index).unwrap_or(&str_len).clone() as usize;
+    let start = *indices_indexes.get(start_index).unwrap_or(&str_len) as usize;
+    let end = *indices_indexes.get(end_index).unwrap_or(&str_len) as usize;
     unsafe {
       // SAFETY: Since `indices` iterates over the `CharIndices` of `self`, we can guarantee
       // that the indices obtained from it will always be within the bounds of `self` and they


### PR DESCRIPTION
This should give us a few second performance improvements when generating large sourcemaps.

Before:

<img width="1054" alt="image" src="https://github.com/web-infra-dev/rspack-sources/assets/1430279/b78517c2-7104-41a1-aa5d-8f499492235a">

After:

<img width="859" alt="image" src="https://github.com/web-infra-dev/rspack-sources/assets/1430279/ebe76528-82e7-4d70-8b49-02ca42fdfff0">
