### PR TITLE
perf: optimize decode mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +447,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rspack_sources"
 version = "0.2.15"
 dependencies = [
+ "arrayvec",
  "base64-simd",
  "codspeed-criterion-compat",
  "criterion",
@@ -451,7 +458,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "smallvec",
  "str_indices",
  "substring",
  "twox-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ dyn-clone = "1"
 rustc-hash = "1"
 dashmap = "5"
 substring = "1"
-smallvec = "1.11.2"
 memchr = "2.6.4"
 str_indices = "0.4.3"
 
 codspeed-criterion-compat = { version = "2.3.3", default-features = false, optional = true }
+arrayvec = "0.7.4"
 
 [dev-dependencies]
 twox-hash = "1"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -655,7 +655,7 @@ fn stream_chunks_of_source_map_final(
     }
   };
   for mapping in source_map.decoded_mappings() {
-    on_mapping(&mapping);
+    on_mapping(mapping);
   }
   result
 }
@@ -796,7 +796,7 @@ fn stream_chunks_of_source_map_full(
   };
 
   for mapping in source_map.decoded_mappings() {
-    on_mapping(&mapping);
+    on_mapping(mapping);
   }
   on_mapping(&Mapping {
     generated_line: final_line,
@@ -859,7 +859,7 @@ fn stream_chunks_of_source_map_lines_final(
     }
   };
   for mapping in source_map.decoded_mappings() {
-    on_mapping(&mapping);
+    on_mapping(mapping);
   }
   result
 }
@@ -927,7 +927,7 @@ fn stream_chunks_of_source_map_lines_full(
     }
   };
   for mapping in source_map.decoded_mappings() {
-    on_mapping(&mapping);
+    on_mapping(mapping);
   }
   while current_generated_line as usize <= lines.len() {
     on_chunk(

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,3 +1,4 @@
+use arrayvec::ArrayVec;
 use rustc_hash::FxHashMap as HashMap;
 use std::{
   borrow::{BorrowMut, Cow},
@@ -136,7 +137,7 @@ pub struct SegmentIter<'a> {
   original_column: u32,
   name_index: u32,
   line: &'a str,
-  nums: Vec<i64>,
+  nums: ArrayVec<i64, 5>,
   segment_cursor: usize,
 }
 
@@ -152,7 +153,7 @@ impl<'a> SegmentIter<'a> {
       generated_line: 0,
       segment_cursor: 0,
       generated_column: 0,
-      nums: Vec::with_capacity(5),
+      nums: ArrayVec::new(),
     }
   }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -233,17 +233,9 @@ impl SourceMap {
 
   /// Get the decoded mappings in [SourceMap].
   pub fn decoded_mappings(&'_ self) -> &[Mapping] {
-    self.decoded_mappings.get_or_init(|| {
-      let mut decoded_mappings = Vec::with_capacity(
-        self
-          .mappings
-          .lines()
-          .filter(|line| !line.is_empty())
-          .count(),
-      );
-      decoded_mappings.extend(decode_mappings(self));
-      decoded_mappings
-    })
+    self
+      .decoded_mappings
+      .get_or_init(|| decode_mappings(self).collect::<Vec<_>>())
   }
 
   /// Get the mappings string in [SourceMap].

--- a/src/source.rs
+++ b/src/source.rs
@@ -232,12 +232,18 @@ impl SourceMap {
   }
 
   /// Get the decoded mappings in [SourceMap].
-  pub fn decoded_mappings(&'_ self) -> impl IntoIterator<Item = Mapping> + '_ {
-    self
-      .decoded_mappings
-      .get_or_init(|| decode_mappings(self).collect::<Vec<_>>())
-      .clone()
-      .into_iter()
+  pub fn decoded_mappings(&'_ self) -> &[Mapping] {
+    self.decoded_mappings.get_or_init(|| {
+      let mut decoded_mappings = Vec::with_capacity(
+        self
+          .mappings
+          .lines()
+          .filter(|line| !line.is_empty())
+          .count(),
+      );
+      decoded_mappings.extend(decode_mappings(self));
+      decoded_mappings
+    })
   }
 
   /// Get the mappings string in [SourceMap].

--- a/src/vlq.rs
+++ b/src/vlq.rs
@@ -1,6 +1,8 @@
 //! Implements utilities for dealing with the sourcemap vlq encoding.
 //! forked from [rust-sourcemap](https://github.com/getsentry/rust-sourcemap/blob/851f12bfa6c4cf2c737b94734b27f7d9bfb4de86/src/vlq.rs)
 
+use arrayvec::ArrayVec;
+
 use crate::{Error, Result};
 
 const B64_CHARS: &[u8] =
@@ -265,7 +267,7 @@ const B64: [i8; 256] = [
 ];
 
 /// Parses a VLQ segment into a pre-allocated `Vec` instead of returning a new allocation.
-pub fn decode(segment: &str, rv: &mut Vec<i64>) -> Result<()> {
+pub fn decode(segment: &str, rv: &mut ArrayVec<i64, 5>) -> Result<()> {
   let mut cur = 0;
   let mut shift = 0;
 


### PR DESCRIPTION
1. remove unnecessary clone.
2. use arrayvec for fixed-size nums