### PR TITLE
perf: reduce allocations for `split_into_lines`

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -493,8 +493,8 @@ fn split(haystack: &str, needle: u8) -> impl Iterator<Item = &str> {
 }
 
 // /[^\n]+\n?|\n/g
-pub fn split_into_lines(source: &str) -> Vec<&str> {
-  split(source, b'\n').collect()
+pub fn split_into_lines(source: &str) -> impl Iterator<Item = &str> {
+  split(source, b'\n')
 }
 
 pub fn get_generated_source_info(source: &str) -> GeneratedInfo {
@@ -868,7 +868,7 @@ fn stream_chunks_of_source_map_lines_full(
   on_source: OnSource,
   _on_name: OnName,
 ) -> GeneratedInfo {
-  let lines = split_into_lines(source);
+  let lines: Vec<&str> = split_into_lines(source).collect();
   if lines.is_empty() {
     return GeneratedInfo {
       generated_line: 1,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1099,7 +1099,6 @@ pub fn stream_chunks_of_combined_source_map(
                 {
                   Some(Rc::new(
                     split_into_lines(original_source)
-                      .into_iter()
                       .map(|s| WithIndices::new(s.into()))
                       .collect(),
                   ))

--- a/src/replace_source.rs
+++ b/src/replace_source.rs
@@ -570,7 +570,6 @@ impl<T: Source> StreamChunks for ReplaceSource<T> {
         source_content_lines[source_index as usize] =
           source_content.map(|source_content| {
             split_into_lines(source_content)
-              .into_iter()
               .map(|line| line.to_string())
               .collect()
           });

--- a/src/replace_source.rs
+++ b/src/replace_source.rs
@@ -398,7 +398,7 @@ impl<T: Source> StreamChunks for ReplaceSource<T> {
           }
           // Insert replacement content split into chunks by lines
           let repl = &repls[i];
-          let lines: Vec<&str> = split_into_lines(&repl.content);
+          let lines: Vec<&str> = split_into_lines(&repl.content).collect();
           let mut replacement_name_index = mapping
             .original
             .as_ref()
@@ -600,7 +600,7 @@ impl<T: Source> StreamChunks for ReplaceSource<T> {
 
     // Insert remaining replacements content split into chunks by lines
     let mut line = result.generated_line as i64 + generated_line_offset;
-    let matches = split_into_lines(&remainder);
+    let matches: Vec<&str> = split_into_lines(&remainder).collect();
     for (m, content_line) in matches.iter().enumerate() {
       on_chunk(
         Some(content_line),


### PR DESCRIPTION
Comparing to main:

```
rspack_sources/replace_large_minified_source
                        time:   [24.971 ms 25.182 ms 25.407 ms]
                        change: [-8.9345% -7.1393% -5.3586%] (p = 0.00 < 0.05)
                        Performance has improved.
```