### PR TITLE
feat: enforce replacement order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use concat_source::ConcatSource;
 pub use error::{Error, Result};
 pub use original_source::OriginalSource;
 pub use raw_source::RawSource;
-pub use replace_source::ReplaceSource;
+pub use replace_source::{ReplaceSource, ReplacementEnforce};
 pub use source::{
   BoxSource, MapOptions, Mapping, OriginalLocation, Source, SourceExt,
   SourceMap,


### PR DESCRIPTION
HarmonyExportExpressionDependency and PureExpressionDependency need this to enforce replace order, to generate valid code
