### PR TITLE
feat: support `RawStringSource` and `RawBufferSource`

### DIFF
--- a/src/concat_source.rs
+++ b/src/concat_source.rs
@@ -326,7 +326,7 @@ impl<'a> StreamChunks<'a> for ConcatSource {
 
 #[cfg(test)]
 mod tests {
-  use crate::{OriginalSource, RawSource};
+  use crate::{OriginalSource, RawBufferSource, RawSource, RawStringSource};
 
   use super::*;
 
@@ -334,6 +334,106 @@ mod tests {
   fn should_concat_two_sources() {
     let mut source = ConcatSource::new([
       RawSource::from("Hello World\n".to_string()).boxed(),
+      OriginalSource::new(
+        "console.log('test');\nconsole.log('test2');\n",
+        "console.js",
+      )
+      .boxed(),
+    ]);
+    source.add(OriginalSource::new("Hello2\n", "hello.md"));
+
+    let expected_source =
+      "Hello World\nconsole.log('test');\nconsole.log('test2');\nHello2\n";
+    assert_eq!(source.size(), 62);
+    assert_eq!(source.source(), expected_source);
+    assert_eq!(
+      source.map(&MapOptions::new(false)).unwrap(),
+      SourceMap::from_json(
+        r#"{
+          "version": 3,
+          "mappings": ";AAAA;AACA;ACDA",
+          "names": [],
+          "sources": ["console.js", "hello.md"],
+          "sourcesContent": [
+            "console.log('test');\nconsole.log('test2');\n",
+            "Hello2\n"
+          ]
+        }"#,
+      )
+      .unwrap()
+    );
+    assert_eq!(
+      source.map(&MapOptions::default()).unwrap(),
+      SourceMap::from_json(
+        r#"{
+          "version": 3,
+          "mappings": ";AAAA;AACA;ACDA",
+          "names": [],
+          "sources": ["console.js", "hello.md"],
+          "sourcesContent": [
+            "console.log('test');\nconsole.log('test2');\n",
+            "Hello2\n"
+          ]
+        }"#
+      )
+      .unwrap()
+    );
+  }
+
+  #[test]
+  fn should_concat_two_sources2() {
+    let mut source = ConcatSource::new([
+      RawStringSource::from("Hello World\n".to_string()).boxed(),
+      OriginalSource::new(
+        "console.log('test');\nconsole.log('test2');\n",
+        "console.js",
+      )
+      .boxed(),
+    ]);
+    source.add(OriginalSource::new("Hello2\n", "hello.md"));
+
+    let expected_source =
+      "Hello World\nconsole.log('test');\nconsole.log('test2');\nHello2\n";
+    assert_eq!(source.size(), 62);
+    assert_eq!(source.source(), expected_source);
+    assert_eq!(
+      source.map(&MapOptions::new(false)).unwrap(),
+      SourceMap::from_json(
+        r#"{
+          "version": 3,
+          "mappings": ";AAAA;AACA;ACDA",
+          "names": [],
+          "sources": ["console.js", "hello.md"],
+          "sourcesContent": [
+            "console.log('test');\nconsole.log('test2');\n",
+            "Hello2\n"
+          ]
+        }"#,
+      )
+      .unwrap()
+    );
+    assert_eq!(
+      source.map(&MapOptions::default()).unwrap(),
+      SourceMap::from_json(
+        r#"{
+          "version": 3,
+          "mappings": ";AAAA;AACA;ACDA",
+          "names": [],
+          "sources": ["console.js", "hello.md"],
+          "sourcesContent": [
+            "console.log('test');\nconsole.log('test2');\n",
+            "Hello2\n"
+          ]
+        }"#
+      )
+      .unwrap()
+    );
+  }
+
+  #[test]
+  fn should_concat_two_sources3() {
+    let mut source = ConcatSource::new([
+      RawBufferSource::from("Hello World\n".as_bytes()).boxed(),
       OriginalSource::new(
         "console.log('test');\nconsole.log('test2');\n",
         "console.js",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use cached_source::CachedSource;
 pub use concat_source::ConcatSource;
 pub use error::{Error, Result};
 pub use original_source::OriginalSource;
-pub use raw_source::RawSource;
+pub use raw_source::{RawBufferSource, RawSource, RawStringSource};
 pub use replace_source::{ReplaceSource, ReplacementEnforce};
 pub use source::{
   BoxSource, MapOptions, Mapping, OriginalLocation, Source, SourceExt,

--- a/src/raw_source.rs
+++ b/src/raw_source.rs
@@ -215,6 +215,215 @@ impl<'a> StreamChunks<'a> for RawSource {
   }
 }
 
+/// A string variant of [RawSource].
+///
+/// - [webpack-sources docs](https://github.com/webpack/webpack-sources/#rawsource).
+///
+/// ```
+/// use rspack_sources::{MapOptions, RawStringSource, Source};
+///
+/// let code = "some source code";
+/// let s = RawStringSource::from(code.to_string());
+/// assert_eq!(s.source(), code);
+/// assert_eq!(s.map(&MapOptions::default()), None);
+/// assert_eq!(s.size(), 16);
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct RawStringSource(Cow<'static, str>);
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+static_assertions::assert_eq_size!(RawStringSource, [u8; 24]);
+
+impl RawStringSource {
+  /// Create a new [RawStringSource] from a static &str.
+  ///
+  /// ```
+  /// use rspack_sources::{RawStringSource, Source};
+  ///
+  /// let code = "some source code";
+  /// let s = RawStringSource::from_static(code);
+  /// assert_eq!(s.source(), code);
+  /// ```
+  pub fn from_static(s: &'static str) -> Self {
+    Self(Cow::Borrowed(s))
+  }
+}
+
+impl From<String> for RawStringSource {
+  fn from(value: String) -> Self {
+    Self(Cow::Owned(value))
+  }
+}
+
+impl From<&str> for RawStringSource {
+  fn from(value: &str) -> Self {
+    Self(Cow::Owned(value.to_owned()))
+  }
+}
+
+impl Source for RawStringSource {
+  fn source(&self) -> Cow<str> {
+    Cow::Borrowed(&self.0)
+  }
+
+  fn buffer(&self) -> Cow<[u8]> {
+    Cow::Borrowed(self.0.as_bytes())
+  }
+
+  fn size(&self) -> usize {
+    self.0.len()
+  }
+
+  fn map(&self, _: &MapOptions) -> Option<SourceMap> {
+    None
+  }
+
+  fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    writer.write_all(self.0.as_bytes())
+  }
+}
+
+impl std::fmt::Debug for RawStringSource {
+  fn fmt(
+    &self,
+    f: &mut std::fmt::Formatter<'_>,
+  ) -> Result<(), std::fmt::Error> {
+    let mut d = f.debug_tuple("RawStringSource");
+    d.field(&self.0.chars().take(50).collect::<String>());
+    d.finish()
+  }
+}
+
+impl Hash for RawStringSource {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    "RawStringSource".hash(state);
+    self.buffer().hash(state);
+  }
+}
+
+impl<'a> StreamChunks<'a> for RawStringSource {
+  fn stream_chunks(
+    &'a self,
+    options: &MapOptions,
+    on_chunk: OnChunk<'_, 'a>,
+    on_source: OnSource<'_, 'a>,
+    on_name: OnName<'_, 'a>,
+  ) -> crate::helpers::GeneratedInfo {
+    if options.final_source {
+      get_generated_source_info(&self.source())
+    } else {
+      stream_chunks_of_raw_source(
+        &self.0, options, on_chunk, on_source, on_name,
+      )
+    }
+  }
+}
+
+/// A buffer variant of [RawSource].
+///
+/// - [webpack-sources docs](https://github.com/webpack/webpack-sources/#rawsource).
+///
+/// ```
+/// use rspack_sources::{MapOptions, RawBufferSource, Source};
+///
+/// let code = "some source code".as_bytes();
+/// let s = RawBufferSource::from(code);
+/// assert_eq!(s.buffer(), code);
+/// assert_eq!(s.map(&MapOptions::default()), None);
+/// assert_eq!(s.size(), 16);
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct RawBufferSource {
+  value: Vec<u8>,
+  value_as_string: OnceLock<String>,
+}
+
+impl From<Vec<u8>> for RawBufferSource {
+  fn from(value: Vec<u8>) -> Self {
+    Self {
+      value,
+      value_as_string: Default::default(),
+    }
+  }
+}
+
+impl From<&[u8]> for RawBufferSource {
+  fn from(value: &[u8]) -> Self {
+    Self {
+      value: value.to_vec(),
+      value_as_string: Default::default(),
+    }
+  }
+}
+
+impl Source for RawBufferSource {
+  fn source(&self) -> Cow<str> {
+    Cow::Borrowed(
+      self
+        .value_as_string
+        .get_or_init(|| String::from_utf8_lossy(&self.value).to_string()),
+    )
+  }
+
+  fn buffer(&self) -> Cow<[u8]> {
+    Cow::Borrowed(&self.value)
+  }
+
+  fn size(&self) -> usize {
+    self.value.len()
+  }
+
+  fn map(&self, _: &MapOptions) -> Option<SourceMap> {
+    None
+  }
+
+  fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    writer.write_all(&self.value)
+  }
+}
+
+impl std::fmt::Debug for RawBufferSource {
+  fn fmt(
+    &self,
+    f: &mut std::fmt::Formatter<'_>,
+  ) -> Result<(), std::fmt::Error> {
+    let mut d = f.debug_tuple("RawBufferSource");
+    d.field(&self.value.iter().take(50).copied().collect::<Vec<u8>>());
+    d.finish()
+  }
+}
+
+impl Hash for RawBufferSource {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    "RawBufferSource".hash(state);
+    self.buffer().hash(state);
+  }
+}
+
+impl<'a> StreamChunks<'a> for RawBufferSource {
+  fn stream_chunks(
+    &'a self,
+    options: &MapOptions,
+    on_chunk: OnChunk<'_, 'a>,
+    on_source: OnSource<'_, 'a>,
+    on_name: OnName<'_, 'a>,
+  ) -> crate::helpers::GeneratedInfo {
+    if options.final_source {
+      get_generated_source_info(&self.source())
+    } else {
+      stream_chunks_of_raw_source(
+        self
+          .value_as_string
+          .get_or_init(|| String::from_utf8_lossy(&self.value).to_string()),
+        options,
+        on_chunk,
+        on_source,
+        on_name,
+      )
+    }
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use crate::{ConcatSource, OriginalSource, ReplaceSource, SourceExt};

--- a/src/replace_source.rs
+++ b/src/replace_source.rs
@@ -745,7 +745,6 @@ mod tests {
     let mut last_line = 0;
     sourcemap
       .decoded_mappings()
-      .into_iter()
       .map(|token| {
         format!(
           "{}:{} ->{} {}:{}{}",

--- a/src/source.rs
+++ b/src/source.rs
@@ -486,8 +486,8 @@ mod tests {
   use std::collections::HashMap;
 
   use crate::{
-    CachedSource, ConcatSource, OriginalSource, RawSource, ReplaceSource,
-    SourceMapSource, WithoutOriginalOptions,
+    CachedSource, ConcatSource, OriginalSource, RawBufferSource, RawSource,
+    RawStringSource, ReplaceSource, SourceMapSource, WithoutOriginalOptions,
   };
 
   use super::*;
@@ -520,14 +520,24 @@ mod tests {
     CachedSource::new(RawSource::from("e")).hash(&mut state);
     ReplaceSource::new(RawSource::from("f")).hash(&mut state);
     RawSource::from("g").boxed().hash(&mut state);
+    RawStringSource::from_static("a").hash(&mut state);
+    RawBufferSource::from("a".as_bytes()).hash(&mut state);
     (&RawSource::from("h") as &dyn Source).hash(&mut state);
     ReplaceSource::new(RawSource::from("i").boxed()).hash(&mut state);
-    assert_eq!(format!("{:x}", state.finish()), "ef733b8b8ee61bf0");
+    assert_eq!(format!("{:x}", state.finish()), "709931db47fa47dc");
   }
 
   #[test]
   fn eq_available() {
     assert_eq!(RawSource::from("a"), RawSource::from("a"));
+    assert_eq!(
+      RawStringSource::from_static("a"),
+      RawStringSource::from_static("a")
+    );
+    assert_eq!(
+      RawBufferSource::from("a".as_bytes()),
+      RawBufferSource::from("a".as_bytes())
+    );
     assert_eq!(OriginalSource::new("b", ""), OriginalSource::new("b", ""));
     assert_eq!(
       SourceMapSource::new(WithoutOriginalOptions {
@@ -569,7 +579,7 @@ mod tests {
   }
 
   #[test]
-  #[allow(clippy::clone_double_ref)]
+  #[allow(suspicious_double_ref_op)]
   fn clone_available() {
     let a = RawSource::from("a");
     assert_eq!(a, a.clone());
@@ -595,6 +605,10 @@ mod tests {
     assert_eq!(i, i.clone());
     let j = CachedSource::new(RawSource::from("j").boxed());
     assert_eq!(j, j.clone());
+    let k = RawStringSource::from_static("k");
+    assert_eq!(k, k.clone());
+    let l = RawBufferSource::from("l".as_bytes());
+    assert_eq!(l, l.clone());
   }
 
   #[test]
@@ -606,7 +620,7 @@ mod tests {
   }
 
   #[test]
-  #[allow(clippy::clone_double_ref)]
+  #[allow(suspicious_double_ref_op)]
   fn ref_dyn_source_use_hashmap_available() {
     let mut map = HashMap::new();
     let a = &RawSource::from("a") as &dyn Source;


### PR DESCRIPTION
Related: https://github.com/web-infra-dev/rspack-sources/issues/131


Size of types(64-bit machine):
- `RawSource`: 64 bytes
- `RawStringSource`: 24 bytes
- `RawBufferSource`: 56 bytes

Use `RawStringSource` for better memory usage.

**Note**: Size listed does not count for any heap allocated values like `String` or `Vec`.