### PR TITLE
feat: Add support for sourcemap `debugId` property

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -206,6 +206,8 @@ pub struct SourceMap {
   mappings: Arc<str>,
   #[serde(rename = "sourceRoot", skip_serializing_if = "Option::is_none")]
   source_root: Option<Arc<str>>,
+  #[serde(rename = "debugId", skip_serializing_if = "Option::is_none")]
+  debug_id: Option<Arc<str>>,
 }
 
 impl Hash for SourceMap {
@@ -241,6 +243,7 @@ impl SourceMap {
       sources_content: sources_content.into(),
       names: names.into(),
       source_root: None,
+      debug_id: None,
     }
   }
 
@@ -321,6 +324,16 @@ impl SourceMap {
   pub fn set_source_root<T: Into<Arc<str>>>(&mut self, source_root: Option<T>) {
     self.source_root = source_root.map(Into::into);
   }
+
+  /// Set the debug_id field in [SourceMap].
+  pub fn set_debug_id<T: Into<Arc<str>>>(&mut self, debug_id: Option<T>) {
+    self.debug_id = debug_id.map(Into::into);
+  }
+
+  /// Get the debug_id field in [SourceMap].
+  pub fn get_debug_id(&self) -> Option<&str> {
+    self.debug_id.as_deref()
+  }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -333,6 +346,8 @@ struct RawSourceMap {
   pub sources_content: Option<Vec<Option<String>>>,
   pub names: Option<Vec<Option<String>>>,
   pub mappings: String,
+  #[serde(rename = "debugId")]
+  pub debug_id: Option<String>,
 }
 
 impl RawSourceMap {
@@ -411,6 +426,7 @@ impl TryFrom<RawSourceMap> for SourceMap {
       .collect::<Vec<_>>()
       .into();
     let source_root = raw.source_root.map(Into::into);
+    let debug_id = raw.debug_id.map(Into::into);
 
     Ok(Self {
       version: 3,
@@ -420,6 +436,7 @@ impl TryFrom<RawSourceMap> for SourceMap {
       sources_content,
       names,
       source_root,
+      debug_id,
     })
   }
 }


### PR DESCRIPTION
Debug IDs are detailed in the [TC39 proposal](https://github.com/tc39/source-map/blob/main/proposals/debug-id.md). 

Debug IDs are unique IDs generated from a deterministic hash of the source code which are then injected/included in both source and sourcemap. They can be used to easily identify the correct sourcemaps in production. 

Although the proposal is only at stage 2, the debug ID in source and sourcemap is well defined and it's only the JavaScript API which is likely to change before stage 3. Sentry already process hundreds of millions of source files per month containing debug ids! 

I've recently added support for injecting debug IDs to [webpack](https://github.com/webpack/webpack/pull/18947), [Rollup](https://github.com/rollup/rollup/pull/5712/), and [Rolldown](https://github.com/rolldown/rolldown/pull/2516) and wanted to get them working in Rspack too with the same API as webpack. 