### PR TITLE
perf: using writer to calculate concat source buffer

### DIFF
--- a/src/cached_source.rs
+++ b/src/cached_source.rs
@@ -82,7 +82,9 @@ impl<T: Source + Hash + PartialEq + Eq + 'static> Source for CachedSource<T> {
   }
 
   fn buffer(&self) -> Cow<[u8]> {
-    self.inner.buffer()
+    let mut buffer = vec![];
+    self.to_writer(&mut buffer).unwrap();
+    Cow::Owned(buffer)
   }
 
   fn size(&self) -> usize {

--- a/src/concat_source.rs
+++ b/src/concat_source.rs
@@ -141,12 +141,9 @@ impl Source for ConcatSource {
     if children.len() == 1 {
       children[0].buffer()
     } else {
-      let all = children
-        .iter()
-        .map(|child| child.buffer())
-        .collect::<Vec<_>>()
-        .concat();
-      Cow::Owned(all)
+      let mut buffer = vec![];
+      self.to_writer(&mut buffer).unwrap();
+      Cow::Owned(buffer)
     }
   }
 


### PR DESCRIPTION
This PR optimizes buffer calculation by replacing direct buffer concatenation with a writer-based approach to improve performance when calculating source buffers.