### PR TITLE
perf: RawBufferSource value_as_string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +425,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +483,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -557,6 +606,7 @@ dependencies = [
  "dyn-clone",
  "itertools 0.13.0",
  "memchr",
+ "ouroboros",
  "regex",
  "rustc-hash",
  "serde",
@@ -964,6 +1014,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ itertools = "0.13"
 codspeed-criterion-compat = { version = "2.7.2", default-features = false, optional = true }
 static_assertions = "1.1.0"
 simd-json = "0.14.3"
+ouroboros = "0.18.5"
 
 [dev-dependencies]
 twox-hash = "2.1.0"

--- a/src/raw_source.rs
+++ b/src/raw_source.rs
@@ -375,9 +375,9 @@ pub struct RawBufferSource {
 impl RawBufferSource {
   fn get_or_init_value_as_string(&self) -> &str {
     self.with(|fields| {
-      fields.value_as_string.get_or_init(|| {
-        String::from_utf8_lossy(&fields.value)
-      })
+      fields
+        .value_as_string
+        .get_or_init(|| String::from_utf8_lossy(fields.value))
     })
   }
 }
@@ -387,7 +387,8 @@ impl Clone for RawBufferSource {
     RawBufferSourceBuilder {
       value: self.borrow_value().clone(),
       value_as_string_builder: |_: &Vec<u8>| Default::default(),
-    }.build()
+    }
+    .build()
   }
 }
 
@@ -404,7 +405,8 @@ impl From<Vec<u8>> for RawBufferSource {
     RawBufferSourceBuilder {
       value,
       value_as_string_builder: |_: &Vec<u8>| Default::default(),
-    }.build()
+    }
+    .build()
   }
 }
 
@@ -413,7 +415,8 @@ impl From<&[u8]> for RawBufferSource {
     RawBufferSourceBuilder {
       value: value.to_vec(),
       value_as_string_builder: |_: &Vec<u8>| Default::default(),
-    }.build()
+    }
+    .build()
   }
 }
 
@@ -423,13 +426,11 @@ impl Source for RawBufferSource {
   }
 
   fn rope(&self) -> Rope<'_> {
-    Rope::from(
-      self.get_or_init_value_as_string()
-    )
+    Rope::from(self.get_or_init_value_as_string())
   }
 
   fn buffer(&self) -> Cow<[u8]> {
-    Cow::Borrowed(&self.borrow_value())
+    Cow::Borrowed(self.borrow_value())
   }
 
   fn size(&self) -> usize {


### PR DESCRIPTION
This PR optimizes the RawBufferSource struct to avoid unnecessary string allocations by using self-referential structs and Cow<'this, str> instead of String. The change leverages the ouroboros crate to create self-referential structures that can borrow from their own data.